### PR TITLE
[mark] Collapse whitespace in paragraphs.

### DIFF
--- a/mark/src/tree.rs
+++ b/mark/src/tree.rs
@@ -46,7 +46,9 @@ fn write_inlines<'a>(f: &mut fmt::Formatter, inlines: &[Inline<'a>]) -> fmt::Res
         if i != 0 {
             writeln!(f,)?;
         }
-        write!(f, "{}", inline.to_string())?;
+        let s = inline.to_string();
+        let strs: Vec<&str> = s.split_whitespace().collect();
+        write!(f, "{}", strs.join(" "))?;
     }
     Ok(())
 }
@@ -70,7 +72,15 @@ impl<'a> fmt::Display for Block<'a> {
                     write!(f, " class='language-{}'", lang)?;
                 }
                 write!(f, ">")?;
-                write_inlines(f, inlines)?;
+                // This does not use the generic `write_inlines` method because
+                // the the generic method trims and collapses whitespace which
+                // is not desired for code blocks.
+                for (i, inline) in inlines.iter().enumerate() {
+                    if i != 0 {
+                        writeln!(f,)?;
+                    }
+                    write!(f, "{}", inline.to_string())?;
+                }
                 write!(f, "</code></pre>")?;
             }
             Block::Header(lvl, inlines) => {

--- a/mark/tests/fixtures/data/fenced_code.html
+++ b/mark/tests/fixtures/data/fenced_code.html
@@ -9,8 +9,8 @@ layout (location = 0) out vec4 frag_color;
 void main() {
   frag_color = vec4(1.0, 0.2, 0.8, 1.0);
 }</code></pre>
-<p>    Just a paragraph, no indented code blocks.
-    With two lines.</p>
+<p>Just a paragraph, no indented code blocks.
+With two lines.</p>
 <pre><code class='language-rust'>fn test() -> bool {
   1 == 2
 }</code></pre>

--- a/mark/tests/fixtures/data/paragraphs.html
+++ b/mark/tests/fixtures/data/paragraphs.html
@@ -3,3 +3,5 @@ with two lines.</p>
 <p>And a second paragraph comes after the hard break.
 It has multiple lines as well.
 Three this time.</p>
+<p>Trims excess whitespace
+With many lines</p>

--- a/mark/tests/fixtures/data/paragraphs.md
+++ b/mark/tests/fixtures/data/paragraphs.md
@@ -4,3 +4,7 @@ with two lines.
 And a second paragraph comes after the hard break.
 It has multiple lines as well.
 Three this time.
+
+
+   Trims    excess    whitespace
+   With many     lines


### PR DESCRIPTION
Whitespace is now collapsed to a single space when multiple items are
provided in a row.