### PR TITLE
[mark] Add newlines to output HTML.

### DIFF
--- a/mark/src/tree.rs
+++ b/mark/src/tree.rs
@@ -17,10 +17,7 @@ impl<'a> Doc<'a> {
 impl<'a> fmt::Display for Doc<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         for idx in 0..self.blocks.len() {
-            if idx > 0 {
-                writeln!(f,)?;
-            }
-            write!(f, "{}", self.blocks[idx].to_string())?;
+            writeln!(f, "{}", self.blocks[idx].to_string())?;
         }
         Ok(())
     }
@@ -42,6 +39,8 @@ pub enum Block<'a> {
 }
 
 fn write_inlines<'a>(f: &mut fmt::Formatter, inlines: &[Inline<'a>]) -> fmt::Result {
+    // Note, writeln! is not used here because we don't want to inject a newline
+    // into the last line of output.
     for (i, inline) in inlines.iter().enumerate() {
         if i != 0 {
             writeln!(f,)?;
@@ -58,13 +57,10 @@ impl<'a> fmt::Display for Block<'a> {
         match self {
             Block::Blockquote(blocks) => {
                 write!(f, "<blockquote>")?;
-                for (i, block) in blocks.iter().enumerate() {
-                    if i != 0 {
-                        writeln!(f,)?;
-                    }
+                for block in blocks.iter() {
                     write!(f, "{}", block.to_string())?;
                 }
-                write!(f, "</blockquote>")?;
+                writeln!(f, "</blockquote>")?;
             }
             Block::Code(lang, inlines) => {
                 write!(f, "<pre><code")?;
@@ -75,26 +71,29 @@ impl<'a> fmt::Display for Block<'a> {
                 // This does not use the generic `write_inlines` method because
                 // the the generic method trims and collapses whitespace which
                 // is not desired for code blocks.
+                //
+                // writeln! is not used here because we don't want a newline on
+                // the last line of text.
                 for (i, inline) in inlines.iter().enumerate() {
                     if i != 0 {
                         writeln!(f,)?;
                     }
                     write!(f, "{}", inline.to_string())?;
                 }
-                write!(f, "</code></pre>")?;
+                writeln!(f, "</code></pre>")?;
             }
             Block::Header(lvl, inlines) => {
                 write!(f, "<h{}>", lvl)?;
                 write_inlines(f, inlines)?;
-                write!(f, "</h{}>", lvl)?;
+                writeln!(f, "</h{}>", lvl)?;
             }
             Block::Paragraph(inlines) => {
                 write!(f, "<p>")?;
                 write_inlines(f, inlines)?;
-                write!(f, "</p>")?;
+                writeln!(f, "</p>")?;
             }
             Block::ThematicBreak => {
-                write!(f, "<hr />")?;
+                writeln!(f, "<hr />")?;
             }
         };
         Ok(())

--- a/mark/tests/fixtures/data/blockquote.html
+++ b/mark/tests/fixtures/data/blockquote.html
@@ -1,2 +1,3 @@
 <blockquote><p>This is a blockquote
-with two lines.</p></blockquote>
+with two lines.</p>
+</blockquote>

--- a/mark/tests/fixtures/data/fenced_code.html
+++ b/mark/tests/fixtures/data/fenced_code.html
@@ -2,6 +2,7 @@
   x = x + 1
   x
 end</code></pre>
+
 <pre><code class='language-glsl'>#version 460
 
 layout (location = 0) out vec4 frag_color;
@@ -9,13 +10,17 @@ layout (location = 0) out vec4 frag_color;
 void main() {
   frag_color = vec4(1.0, 0.2, 0.8, 1.0);
 }</code></pre>
+
 <p>Just a paragraph, no indented code blocks.
 With two lines.</p>
+
 <pre><code class='language-rust'>fn test() -> bool {
   1 == 2
 }</code></pre>
+
 <pre><code>A shorter marker.
 ```</code></pre>
+
 <pre><code>Different marker
 ```</code></pre>
 

--- a/mark/tests/fixtures/data/headers.html
+++ b/mark/tests/fixtures/data/headers.html
@@ -1,14 +1,27 @@
 <h1>Header level 1</h1>
+
 <h2>Header level 2</h2>
+
 <h3>Header level 3</h3>
+
 <h4>Header level 4</h4>
+
 <h5>Header level 5</h5>
+
 <h6>Header level 6</h6>
+
 <p>####### Not a header</p>
+
 <h6>Header level 6</h6>
+
 <h5>Header level 5</h5>
+
 <h4>Header level 4</h4>
+
 <h3>Header level 3</h3>
+
 <h2>Header level 2</h2>
+
 <h1>Header level 1</h1>
+
 <h1></h1>

--- a/mark/tests/fixtures/data/paragraphs.html
+++ b/mark/tests/fixtures/data/paragraphs.html
@@ -1,7 +1,9 @@
 <p>This is the first paragraph
 with two lines.</p>
+
 <p>And a second paragraph comes after the hard break.
 It has multiple lines as well.
 Three this time.</p>
+
 <p>Trims excess whitespace
 With many lines</p>

--- a/mark/tests/fixtures/data/thematic_breaks.html
+++ b/mark/tests/fixtures/data/thematic_breaks.html
@@ -1,7 +1,13 @@
 <hr />
+
 <hr />
+
 <hr />
+
 <hr />
+
 <hr />
+
 <p>-- not a break --</p>
+
 <hr />

--- a/mark/tests/fixtures/mod.rs
+++ b/mark/tests/fixtures/mod.rs
@@ -21,7 +21,8 @@ fn compare(name: &str) {
         .unwrap();
 
     println!("{}", src);
-    assert_diff!(&result, &mark::to_html(&src), "\n", 0);
+    let actual = &mark::to_html(&src);
+    assert_diff!(&result, actual.trim_end(), "\n", 0);
 }
 
 #[test]


### PR DESCRIPTION
Update the way the HTML is written to inject some extra newlines into
the output to aide in readability.