### PR TITLE
Switch to pretty_asserions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,6 +178,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8f45d9ad417bcef4817d614a501ab55cdd96a6fdb24f49aab89a54acfd66b19"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -668,8 +678,8 @@ name = "mark"
 version = "0.1.0"
 dependencies = [
  "clap",
- "difference",
  "lazy_static",
+ "pretty_assertions",
  "regex",
 ]
 
@@ -860,6 +870,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
+name = "output_vt100"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -999,6 +1018,18 @@ name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+
+[[package]]
+name = "pretty_assertions"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f81e1644e1b54f5a68959a29aa86cde704219254669da328ecfdf6a1f09d427"
+dependencies = [
+ "ansi_term",
+ "ctor",
+ "difference",
+ "output_vt100",
+]
 
 [[package]]
 name = "proc-macro-hack"

--- a/mark/Cargo.toml
+++ b/mark/Cargo.toml
@@ -22,4 +22,4 @@ regex = { version = "1.4" }
 lazy_static = { version = "1.4" }
 
 [dev-dependencies]
-difference = { version = "2.0" }
+pretty_assertions = { version = "0.6" }

--- a/mark/tests/fixtures/mod.rs
+++ b/mark/tests/fixtures/mod.rs
@@ -1,4 +1,4 @@
-use difference::assert_diff;
+use pretty_assertions::assert_eq;
 use std::fs::File;
 use std::io::Read;
 use std::path::Path;
@@ -22,7 +22,7 @@ fn compare(name: &str) {
 
     println!("{}", src);
     let actual = &mark::to_html(&src);
-    assert_diff!(&result, actual.trim_end(), "\n", 0);
+    assert_eq!(result, actual.trim_end());
 }
 
 #[test]


### PR DESCRIPTION
Switch from difference to pretty_assertions. The output messages when
missing newlines is a lot easier to determine with pretty_assertions.