### PR TITLE
[mark] Add strong support.

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -20,8 +20,8 @@
  * [x] Blockquotes
  * [x] Paragraphs
  * [x] Setex Headers
- * [ ] Emphasis  _em_
- * [ ] Strong *strong*
+ * [x] Emphasis  _em_
+ * [x] Strong *strong*
  * [ ] Superscript e^2^
  * [ ] Subscript e~2~
  * [x] Lists

--- a/mark/src/tree.rs
+++ b/mark/src/tree.rs
@@ -52,8 +52,8 @@ pub enum Block<'a> {
     ThematicBreak,
     /// A text block
     Text(&'a str),
-    /// An emphasis block
-    Emphasis(Vec<Block<'a>>),
+    /// An inline block
+    Inline(&'a str, Vec<Block<'a>>),
 }
 
 fn write_blocks<'a>(f: &mut fmt::Formatter, blocks: &[Block<'a>]) -> fmt::Result {
@@ -116,10 +116,10 @@ impl<'a> fmt::Display for Block<'a> {
             }
             Block::ThematicBreak => writeln!(f, "<hr />")?,
             Block::Text(txt) => write!(f, "{}", txt)?,
-            Block::Emphasis(blocks) => {
-                write!(f, "<em>")?;
+            Block::Inline(el, blocks) => {
+                write!(f, "<{}>", el)?;
                 write_blocks(f, blocks)?;
-                write!(f, "</em>")?;
+                write!(f, "</{}>", el)?;
             }
         };
         Ok(())

--- a/mark/tests/fixtures/data/em.md
+++ b/mark/tests/fixtures/data/em.md
@@ -1,1 +1,1 @@
-This is *em* text.
+This is _em_ text.

--- a/mark/tests/fixtures/data/strong.html
+++ b/mark/tests/fixtures/data/strong.html
@@ -1,0 +1,1 @@
+<p>This is <strong>strong</strong> text.</p>

--- a/mark/tests/fixtures/data/strong.md
+++ b/mark/tests/fixtures/data/strong.md
@@ -1,0 +1,1 @@
+This is *strong* text.

--- a/mark/tests/fixtures/mod.rs
+++ b/mark/tests/fixtures/mod.rs
@@ -60,3 +60,7 @@ pub fn em() {
     compare("em")
 }
 
+#[test]
+pub fn strong() {
+    compare("strong")
+}


### PR DESCRIPTION
Add parsing of '*' as `strong`. This also fixes `_` to be `em`.