### PR TITLE
[mark] Blockquote tests.

### DIFF
--- a/mark/tests/fixtures/cm/block-quotes-201.html
+++ b/mark/tests/fixtures/cm/block-quotes-201.html
@@ -1,4 +1,6 @@
-<pre><code>&gt; # Foo
-&gt; bar
-&gt; baz
-</code></pre>
+<p>Deviates: No indented code blocks.</p>
+<blockquote>
+<h1>Foo</h1>
+<p>bar
+baz</p>
+</blockquote>

--- a/mark/tests/fixtures/cm/block-quotes-201.md
+++ b/mark/tests/fixtures/cm/block-quotes-201.md
@@ -1,3 +1,5 @@
+Deviates: No indented code blocks.
+
     > # Foo
     > bar
     > baz

--- a/mark/tests/fixtures/cm/block-quotes-202.html
+++ b/mark/tests/fixtures/cm/block-quotes-202.html
@@ -1,5 +1,6 @@
+<p>Deviates. Blockquotes start each line with >.</p>
 <blockquote>
 <h1>Foo</h1>
-<p>bar
-baz</p>
+<p>bar</p>
 </blockquote>
+<p>baz</p>

--- a/mark/tests/fixtures/cm/block-quotes-202.md
+++ b/mark/tests/fixtures/cm/block-quotes-202.md
@@ -1,3 +1,5 @@
+Deviates. Blockquotes start each line with >.
+
 > # Foo
 > bar
 baz

--- a/mark/tests/fixtures/cm/block-quotes-203.html
+++ b/mark/tests/fixtures/cm/block-quotes-203.html
@@ -1,5 +1,8 @@
+<p>Deviates: Blockquote lines must all start with >.</p>
 <blockquote>
-<p>bar
-baz
-foo</p>
+<p>bar</p>
+</blockquote>
+<p>baz</p>
+<blockquote>
+<p>foo</p>
 </blockquote>

--- a/mark/tests/fixtures/cm/block-quotes-203.md
+++ b/mark/tests/fixtures/cm/block-quotes-203.md
@@ -1,3 +1,5 @@
+Deviates: Blockquote lines must all start with >.
+
 > bar
 baz
 > foo

--- a/mark/tests/fixtures/cm/block-quotes-205.html
+++ b/mark/tests/fixtures/cm/block-quotes-205.html
@@ -1,8 +1,14 @@
+<p>Deviates: Blockquote starts each line with a >.
+LI elements wrap contents in p elements.</p>
 <blockquote>
 <ul>
-<li>foo</li>
+<li>
+<p>foo</p>
+</li>
 </ul>
 </blockquote>
 <ul>
-<li>bar</li>
+<li>
+<p>bar</p>
+</li>
 </ul>

--- a/mark/tests/fixtures/cm/block-quotes-205.md
+++ b/mark/tests/fixtures/cm/block-quotes-205.md
@@ -1,2 +1,5 @@
+Deviates: Blockquote starts each line with a >.
+LI elements wrap contents in p elements.
+
 > - foo
 - bar

--- a/mark/tests/fixtures/cm/block-quotes-206.html
+++ b/mark/tests/fixtures/cm/block-quotes-206.html
@@ -1,6 +1,6 @@
+<p>Deviates: Blockquote must start each line with >.
+No indented code blocks.</p>
 <blockquote>
-<pre><code>foo
-</code></pre>
+<p>foo</p>
 </blockquote>
-<pre><code>bar
-</code></pre>
+<p>bar</p>

--- a/mark/tests/fixtures/cm/block-quotes-206.md
+++ b/mark/tests/fixtures/cm/block-quotes-206.md
@@ -1,2 +1,5 @@
+Deviates: Blockquote must start each line with >.
+No indented code blocks.
+
 >     foo
     bar

--- a/mark/tests/fixtures/cm/block-quotes-208.html
+++ b/mark/tests/fixtures/cm/block-quotes-208.html
@@ -1,4 +1,10 @@
+<p>Deviates: Blockquote must start with > on each line.
+No indented code blocks.</p>
 <blockquote>
-<p>foo
-- bar</p>
+<p>foo</p>
 </blockquote>
+<ul>
+<li>
+<p>bar</p>
+</li>
+</ul>

--- a/mark/tests/fixtures/cm/block-quotes-208.md
+++ b/mark/tests/fixtures/cm/block-quotes-208.md
@@ -1,2 +1,5 @@
+Deviates: Blockquote must start with > on each line.
+No indented code blocks.
+
 > foo
     - bar

--- a/mark/tests/fixtures/cm/block-quotes-217.html
+++ b/mark/tests/fixtures/cm/block-quotes-217.html
@@ -1,4 +1,5 @@
+<p>Deviates: Blockquote starts each line with >.</p>
 <blockquote>
-<p>bar
-baz</p>
+<p>bar</p>
 </blockquote>
+<p>baz</p>

--- a/mark/tests/fixtures/cm/block-quotes-217.md
+++ b/mark/tests/fixtures/cm/block-quotes-217.md
@@ -1,2 +1,4 @@
+Deviates: Blockquote starts each line with >.
+
 > bar
 baz

--- a/mark/tests/fixtures/cm/block-quotes-220.html
+++ b/mark/tests/fixtures/cm/block-quotes-220.html
@@ -1,8 +1,9 @@
+<p>Deviates: Blockquote must start each line with a >.</p>
 <blockquote>
 <blockquote>
 <blockquote>
-<p>foo
-bar</p>
+<p>foo</p>
 </blockquote>
 </blockquote>
 </blockquote>
+<p>bar</p>

--- a/mark/tests/fixtures/cm/block-quotes-220.md
+++ b/mark/tests/fixtures/cm/block-quotes-220.md
@@ -1,2 +1,4 @@
+Deviates: Blockquote must start each line with a >.
+
 > > > foo
 bar

--- a/mark/tests/fixtures/cm/block-quotes-221.html
+++ b/mark/tests/fixtures/cm/block-quotes-221.html
@@ -1,9 +1,12 @@
+<p>Deviates: Blockquotes must have leading > character.</p>
 <blockquote>
 <blockquote>
 <blockquote>
-<p>foo
-bar
-baz</p>
+<p>foo</p>
 </blockquote>
+</blockquote>
+<p>bar</p>
+<blockquote>
+<p>baz</p>
 </blockquote>
 </blockquote>

--- a/mark/tests/fixtures/cm/block-quotes-221.md
+++ b/mark/tests/fixtures/cm/block-quotes-221.md
@@ -1,3 +1,5 @@
+Deviates: Blockquotes must have leading > character.
+
 >>> foo
 > bar
 >>baz

--- a/mark/tests/fixtures/cm/block-quotes-222.html
+++ b/mark/tests/fixtures/cm/block-quotes-222.html
@@ -1,6 +1,6 @@
+<p>Deviates: No indented code blocks.</p>
 <blockquote>
-<pre><code>code
-</code></pre>
+<p>code</p>
 </blockquote>
 <blockquote>
 <p>not code</p>

--- a/mark/tests/fixtures/cm/block-quotes-222.md
+++ b/mark/tests/fixtures/cm/block-quotes-222.md
@@ -1,3 +1,5 @@
+Deviates: No indented code blocks.
+
 >     code
 
 >    not code

--- a/mark/tests/fixtures/cm/mod.rs
+++ b/mark/tests/fixtures/cm/mod.rs
@@ -1121,19 +1121,16 @@ fn block_quotes_200() {
 }
 
 #[test]
-#[ignore]
 fn block_quotes_201() {
     compare("cm/block-quotes-201")
 }
 
 #[test]
-#[ignore]
 fn block_quotes_202() {
     compare("cm/block-quotes-202")
 }
 
 #[test]
-#[ignore]
 fn block_quotes_203() {
     compare("cm/block-quotes-203")
 }
@@ -1144,13 +1141,11 @@ fn block_quotes_204() {
 }
 
 #[test]
-#[ignore]
 fn block_quotes_205() {
     compare("cm/block-quotes-205")
 }
 
 #[test]
-#[ignore]
 fn block_quotes_206() {
     compare("cm/block-quotes-206")
 }
@@ -1161,7 +1156,6 @@ fn block_quotes_207() {
 }
 
 #[test]
-#[ignore]
 fn block_quotes_208() {
     compare("cm/block-quotes-208")
 }
@@ -1207,7 +1201,6 @@ fn block_quotes_216() {
 }
 
 #[test]
-#[ignore]
 fn block_quotes_217() {
     compare("cm/block-quotes-217")
 }
@@ -1223,19 +1216,16 @@ fn block_quotes_219() {
 }
 
 #[test]
-#[ignore]
 fn block_quotes_220() {
     compare("cm/block-quotes-220")
 }
 
 #[test]
-#[ignore]
 fn block_quotes_221() {
     compare("cm/block-quotes-221")
 }
 
 #[test]
-#[ignore]
 fn block_quotes_222() {
     compare("cm/block-quotes-222")
 }


### PR DESCRIPTION
Update blockquote tests as needed. Each line of a blockquote must start
with a >. There are no lazy continuations allowed.