### PR TITLE
[mark] Enable paragraph test.

### DIFF
--- a/mark/tests/fixtures/cm/mod.rs
+++ b/mark/tests/fixtures/cm/mod.rs
@@ -1083,7 +1083,6 @@ fn paragraphs_194() {
 }
 
 #[test]
-#[ignore]
 fn paragraphs_195() {
     compare("cm/paragraphs-195")
 }

--- a/mark/tests/fixtures/cm/paragraphs-195.html
+++ b/mark/tests/fixtures/cm/paragraphs-195.html
@@ -1,3 +1,3 @@
-<pre><code>aaa
-</code></pre>
-<p>bbb</p>
+<p>Deviates. No indented code blocks.</p>
+<p>aaa
+bbb</p>

--- a/mark/tests/fixtures/cm/paragraphs-195.md
+++ b/mark/tests/fixtures/cm/paragraphs-195.md
@@ -1,2 +1,4 @@
+Deviates. No indented code blocks.
+
     aaa
 bbb


### PR DESCRIPTION
Mark paragraph test as deviates due to no indented code blocks.