### PR TITLE
[mark] Fixup some fenced code examples.

### DIFF
--- a/mark/src/tree.rs
+++ b/mark/src/tree.rs
@@ -74,7 +74,7 @@ impl<'a> fmt::Display for Block<'a> {
             Block::Code(lang, lines) => {
                 write!(f, "<pre><code")?;
                 if let Some(lang) = lang {
-                    write!(f, " class='language-{}'", lang)?;
+                    write!(f, " class=\"language-{}\"", lang)?;
                 }
                 write!(f, ">")?;
                 write_blocks(f, lines)?;

--- a/mark/tests/fixtures/cm/fenced-code-blocks-104.html
+++ b/mark/tests/fixtures/cm/fenced-code-blocks-104.html
@@ -1,4 +1,3 @@
-<pre><code>```
-aaa
-```
+<p>Deviates: No indented code blocks.</p>
+<pre><code>aaa
 </code></pre>

--- a/mark/tests/fixtures/cm/fenced-code-blocks-104.md
+++ b/mark/tests/fixtures/cm/fenced-code-blocks-104.md
@@ -1,3 +1,5 @@
+Deviates: No indented code blocks.
+
     ```
     aaa
     ```

--- a/mark/tests/fixtures/cm/fenced-code-blocks-107.html
+++ b/mark/tests/fixtures/cm/fenced-code-blocks-107.html
@@ -1,3 +1,3 @@
+<p>Deviates: No indented code blocks.</p>
 <pre><code>aaa
-    ```
 </code></pre>

--- a/mark/tests/fixtures/cm/fenced-code-blocks-107.md
+++ b/mark/tests/fixtures/cm/fenced-code-blocks-107.md
@@ -1,3 +1,5 @@
+Deviates: No indented code blocks.
+
 ```
 aaa
     ```

--- a/mark/tests/fixtures/cm/mod.rs
+++ b/mark/tests/fixtures/cm/mod.rs
@@ -472,13 +472,11 @@ fn indented_code_blocks_88() {
 }
 
 #[test]
-#[ignore]
 fn fenced_code_blocks_89() {
     compare("cm/fenced-code-blocks-89")
 }
 
 #[test]
-#[ignore]
 fn fenced_code_blocks_90() {
     compare("cm/fenced-code-blocks-90")
 }
@@ -535,25 +533,21 @@ fn fenced_code_blocks_100() {
 }
 
 #[test]
-#[ignore]
 fn fenced_code_blocks_101() {
     compare("cm/fenced-code-blocks-101")
 }
 
 #[test]
-#[ignore]
 fn fenced_code_blocks_102() {
     compare("cm/fenced-code-blocks-102")
 }
 
 #[test]
-#[ignore]
 fn fenced_code_blocks_103() {
     compare("cm/fenced-code-blocks-103")
 }
 
 #[test]
-#[ignore]
 fn fenced_code_blocks_104() {
     compare("cm/fenced-code-blocks-104")
 }
@@ -564,13 +558,11 @@ fn fenced_code_blocks_105() {
 }
 
 #[test]
-#[ignore]
 fn fenced_code_blocks_106() {
     compare("cm/fenced-code-blocks-106")
 }
 
 #[test]
-#[ignore]
 fn fenced_code_blocks_107() {
     compare("cm/fenced-code-blocks-107")
 }
@@ -598,19 +590,16 @@ fn fenced_code_blocks_111() {
 }
 
 #[test]
-#[ignore]
 fn fenced_code_blocks_112() {
     compare("cm/fenced-code-blocks-112")
 }
 
 #[test]
-#[ignore]
 fn fenced_code_blocks_113() {
     compare("cm/fenced-code-blocks-113")
 }
 
 #[test]
-#[ignore]
 fn fenced_code_blocks_114() {
     compare("cm/fenced-code-blocks-114")
 }
@@ -622,7 +611,6 @@ fn fenced_code_blocks_115() {
 }
 
 #[test]
-#[ignore]
 fn fenced_code_blocks_116() {
     compare("cm/fenced-code-blocks-116")
 }

--- a/mark/tests/fixtures/data/fenced_code.html
+++ b/mark/tests/fixtures/data/fenced_code.html
@@ -3,7 +3,7 @@
   x
 end
 </code></pre>
-<pre><code class='language-glsl'>#version 460
+<pre><code class="language-glsl">#version 460
 
 layout (location = 0) out vec4 frag_color;
 
@@ -13,7 +13,7 @@ void main() {
 </code></pre>
 <p>Just a paragraph, no indented code blocks.
 With two lines.</p>
-<pre><code class='language-rust'>fn test() -> bool {
+<pre><code class="language-rust">fn test() -&gt; bool {
   1 == 2
 }
 </code></pre>


### PR DESCRIPTION
Enable several of the fenced code examples. The remaining disabled tests
depend on the behaviour of the inline code blocks which will be fixed
later.