### PR TITLE
[mark] Add setext header support.

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,10 +1,5 @@
 # Todo
 ## Server
- * [x] View assets
- * [x] View notes
-   * [x] View formatted
-   * [x] View plain text
- * [x] Retrieve asset/note folder from ENV
  * [ ] Upload assets
  * [ ] Create note
  * [ ] Edit note
@@ -17,30 +12,14 @@
  * [ ] Configure server Address and Port from ENV
 
 ## Mark
- * [x] Blockquotes
- * [x] Paragraphs
- * [x] Setex Headers
- * [x] Emphasis  _em_
- * [x] Strong *strong*
  * [ ] Superscript e^2^
  * [ ] Subscript e~2~
- * [x] Lists
-   * [x] Ordered (lower alpha, upper alpha, lower roman, upper roman, number)
-   * [x] Unordered
- * [x] Thematic breaks (---, ***, ___)
- * [x] Code blocks (fenced only, no indented code blocks)
- * [x] Inline code blocks
  * [ ] Math blocks
  * [ ] Inline math blocks
- * [ ] Decide on Setex headers
  * [ ] Raw HTML ?
  * [ ] Link definitions
  * [ ] Links (images, note pages, external, email)
  * [ ] Character escapes
-   * [ ] "
-   * [ ] &
-   * [ ] <
-   * [ ] >
    * [ ] --
    * [ ] ---
    * [ ] <=> -> &DoubleLongLeftRightArrow;

--- a/mark/tests/fixtures/cm/mod.rs
+++ b/mark/tests/fixtures/cm/mod.rs
@@ -247,7 +247,6 @@ fn atx_headings_49() {
 }
 
 #[test]
-#[ignore]
 fn setext_headings_50() {
     compare("cm/setext-headings-50")
 }
@@ -265,31 +264,26 @@ fn setext_headings_52() {
 }
 
 #[test]
-#[ignore]
 fn setext_headings_53() {
     compare("cm/setext-headings-53")
 }
 
 #[test]
-#[ignore]
 fn setext_headings_54() {
     compare("cm/setext-headings-54")
 }
 
 #[test]
-#[ignore]
 fn setext_headings_55() {
     compare("cm/setext-headings-55")
 }
 
 #[test]
-#[ignore]
 fn setext_headings_56() {
     compare("cm/setext-headings-56")
 }
 
 #[test]
-#[ignore]
 fn setext_headings_57() {
     compare("cm/setext-headings-57")
 }
@@ -300,13 +294,11 @@ fn setext_headings_58() {
 }
 
 #[test]
-#[ignore]
 fn setext_headings_59() {
     compare("cm/setext-headings-59")
 }
 
 #[test]
-#[ignore]
 fn setext_headings_60() {
     compare("cm/setext-headings-60")
 }
@@ -323,25 +315,21 @@ fn setext_headings_62() {
 }
 
 #[test]
-#[ignore]
 fn setext_headings_63() {
     compare("cm/setext-headings-63")
 }
 
 #[test]
-#[ignore]
 fn setext_headings_64() {
     compare("cm/setext-headings-64")
 }
 
 #[test]
-#[ignore]
 fn setext_headings_65() {
     compare("cm/setext-headings-65")
 }
 
 #[test]
-#[ignore]
 fn setext_headings_66() {
     compare("cm/setext-headings-66")
 }
@@ -357,13 +345,11 @@ fn setext_headings_68() {
 }
 
 #[test]
-#[ignore]
 fn setext_headings_69() {
     compare("cm/setext-headings-69")
 }
 
 #[test]
-#[ignore]
 fn setext_headings_70() {
     compare("cm/setext-headings-70")
 }
@@ -374,13 +360,11 @@ fn setext_headings_71() {
 }
 
 #[test]
-#[ignore]
 fn setext_headings_72() {
     compare("cm/setext-headings-72")
 }
 
 #[test]
-#[ignore]
 fn setext_headings_73() {
     compare("cm/setext-headings-73")
 }
@@ -396,7 +380,6 @@ fn setext_headings_75() {
 }
 
 #[test]
-#[ignore]
 fn setext_headings_76() {
     compare("cm/setext-headings-76")
 }
@@ -584,7 +567,6 @@ fn fenced_code_blocks_110() {
 }
 
 #[test]
-#[ignore]
 fn fenced_code_blocks_111() {
     compare("cm/fenced-code-blocks-111")
 }

--- a/mark/tests/fixtures/cm/setext-headings-50.html
+++ b/mark/tests/fixtures/cm/setext-headings-50.html
@@ -1,2 +1,3 @@
-<h1>Foo <em>bar</em></h1>
-<h2>Foo <em>bar</em></h2>
+<p>Deviates: * is strong not em.</p>
+<h1>Foo <strong>bar</strong></h1>
+<h2>Foo <strong>bar</strong></h2>

--- a/mark/tests/fixtures/cm/setext-headings-50.md
+++ b/mark/tests/fixtures/cm/setext-headings-50.md
@@ -1,3 +1,5 @@
+Deviates: * is strong not em.
+
 Foo *bar*
 =========
 

--- a/mark/tests/fixtures/cm/setext-headings-51.html
+++ b/mark/tests/fixtures/cm/setext-headings-51.html
@@ -1,2 +1,3 @@
-<h1>Foo <em>bar
-baz</em></h1>
+<p>Deviates: * is strong not em.</p>
+<h1>Foo <strong>bar
+baz</strong></h1>

--- a/mark/tests/fixtures/cm/setext-headings-51.md
+++ b/mark/tests/fixtures/cm/setext-headings-51.md
@@ -1,3 +1,5 @@
+Deviates: * is strong not em.
+
 Foo *bar
 baz*
 ====

--- a/mark/tests/fixtures/cm/setext-headings-52.html
+++ b/mark/tests/fixtures/cm/setext-headings-52.html
@@ -1,2 +1,3 @@
+<p>Deviates: * is strong not em.</p>
 <h1>Foo <em>bar
 baz</em></h1>

--- a/mark/tests/fixtures/cm/setext-headings-52.md
+++ b/mark/tests/fixtures/cm/setext-headings-52.md
@@ -1,3 +1,5 @@
+Deviates: * is strong not em.
+
   Foo *bar
 baz*	
 ====

--- a/mark/tests/fixtures/cm/setext-headings-53.html
+++ b/mark/tests/fixtures/cm/setext-headings-53.html
@@ -1,2 +1,4 @@
+<p>Deviates: Setext header requires at least 3 markers.</p>
 <h2>Foo</h2>
-<h1>Foo</h1>
+<p>Foo
+=</p>

--- a/mark/tests/fixtures/cm/setext-headings-53.md
+++ b/mark/tests/fixtures/cm/setext-headings-53.md
@@ -1,3 +1,5 @@
+Deviates: Setext header requires at least 3 markers.
+
 Foo
 -------------------------
 

--- a/mark/tests/fixtures/cm/setext-headings-55.html
+++ b/mark/tests/fixtures/cm/setext-headings-55.html
@@ -1,6 +1,3 @@
-<pre><code>Foo
----
-
-Foo
-</code></pre>
-<hr />
+<p>Deviates: No indented code blocks.</p>
+<h2>Foo</h2>
+<h2>Foo</h2>

--- a/mark/tests/fixtures/cm/setext-headings-55.md
+++ b/mark/tests/fixtures/cm/setext-headings-55.md
@@ -1,3 +1,5 @@
+Deviates: No indented code blocks.
+
     Foo
     ---
 

--- a/mark/tests/fixtures/cm/setext-headings-57.html
+++ b/mark/tests/fixtures/cm/setext-headings-57.html
@@ -1,2 +1,2 @@
-<p>Foo
----</p>
+<p>Deviates: No indented code blocks.</p>
+<h2>Foo</h2>

--- a/mark/tests/fixtures/cm/setext-headings-57.md
+++ b/mark/tests/fixtures/cm/setext-headings-57.md
@@ -1,2 +1,4 @@
+Deviates: No indented code blocks.
+
 Foo
     ---

--- a/mark/tests/fixtures/cm/setext-headings-63.html
+++ b/mark/tests/fixtures/cm/setext-headings-63.html
@@ -1,5 +1,5 @@
+<p>Deviates: Blockquote requires each line start with >.</p>
 <blockquote>
-<p>foo
-bar
-===</p>
+<p>foo</p>
 </blockquote>
+<h1>bar</h1>

--- a/mark/tests/fixtures/cm/setext-headings-63.md
+++ b/mark/tests/fixtures/cm/setext-headings-63.md
@@ -1,3 +1,5 @@
+Deviates: Blockquote requires each line start with >.
+
 > foo
 bar
 ===

--- a/mark/tests/fixtures/cm/setext-headings-64.html
+++ b/mark/tests/fixtures/cm/setext-headings-64.html
@@ -1,4 +1,7 @@
+<p>Deviates: LI elements wrapped in p tag.</p>
 <ul>
-<li>Foo</li>
+<li>
+<p>Foo</p>
+</li>
 </ul>
 <hr />

--- a/mark/tests/fixtures/cm/setext-headings-64.md
+++ b/mark/tests/fixtures/cm/setext-headings-64.md
@@ -1,2 +1,4 @@
+Deviates: LI elements wrapped in p tag.
+
 - Foo
 ---

--- a/mark/tests/fixtures/cm/setext-headings-69.html
+++ b/mark/tests/fixtures/cm/setext-headings-69.html
@@ -1,4 +1,7 @@
+<p>Deviates: LI elements wrapped in p tag.</p>
 <ul>
-<li>foo</li>
+<li>
+<p>foo</p>
+</li>
 </ul>
 <hr />

--- a/mark/tests/fixtures/cm/setext-headings-69.md
+++ b/mark/tests/fixtures/cm/setext-headings-69.md
@@ -1,2 +1,4 @@
+Deviates: LI elements wrapped in p tag.
+
 - foo
 -----

--- a/mark/tests/fixtures/cm/setext-headings-70.html
+++ b/mark/tests/fixtures/cm/setext-headings-70.html
@@ -1,3 +1,2 @@
-<pre><code>foo
-</code></pre>
-<hr />
+<p>Deviates: No indented code blocks.</p>
+<h2>foo</h2>

--- a/mark/tests/fixtures/cm/setext-headings-70.md
+++ b/mark/tests/fixtures/cm/setext-headings-70.md
@@ -1,2 +1,4 @@
+Deviates: No indented code blocks.
+
     foo
 ---

--- a/mark/tests/fixtures/cm/thematic-breaks-29.html
+++ b/mark/tests/fixtures/cm/thematic-breaks-29.html
@@ -1,4 +1,2 @@
-<p>Deviates: Setex header not supported.</p>
-<p>Foo</p>
-<hr />
+<h2>Foo</h2>
 <p>bar</p>

--- a/mark/tests/fixtures/cm/thematic-breaks-29.md
+++ b/mark/tests/fixtures/cm/thematic-breaks-29.md
@@ -1,5 +1,3 @@
-Deviates: Setex header not supported.
-
 Foo
 ---
 bar


### PR DESCRIPTION
Setext header support is added, there are a few disabled tests due to
the interaction with parsing inlines which is currently incorrect.