### PR TITLE
[mark] Enable indented code block tests.

### DIFF
--- a/mark/tests/fixtures/cm/indented-code-blocks-77.html
+++ b/mark/tests/fixtures/cm/indented-code-blocks-77.html
@@ -1,3 +1,3 @@
-<pre><code>a simple
-  indented code block
-</code></pre>
+<p>Deviates: No indented code blocks.</p>
+<p>a simple
+indented code block</p>

--- a/mark/tests/fixtures/cm/indented-code-blocks-77.md
+++ b/mark/tests/fixtures/cm/indented-code-blocks-77.md
@@ -1,2 +1,4 @@
+Deviates: No indented code blocks.
+
     a simple
       indented code block

--- a/mark/tests/fixtures/cm/indented-code-blocks-79.html
+++ b/mark/tests/fixtures/cm/indented-code-blocks-79.html
@@ -1,8 +1,11 @@
+<p>Deviates: LI elements wrapped in p tags.</p>
 <ol>
 <li>
 <p>foo</p>
 <ul>
-<li>bar</li>
+<li>
+<p>bar</p>
+</li>
 </ul>
 </li>
 </ol>

--- a/mark/tests/fixtures/cm/indented-code-blocks-79.md
+++ b/mark/tests/fixtures/cm/indented-code-blocks-79.md
@@ -1,3 +1,5 @@
+Deviates: LI elements wrapped in p tags.
+
 1.  foo
 
     - bar

--- a/mark/tests/fixtures/cm/indented-code-blocks-80.html
+++ b/mark/tests/fixtures/cm/indented-code-blocks-80.html
@@ -1,5 +1,8 @@
-<pre><code>&lt;a/&gt;
-*hi*
-
-- one
-</code></pre>
+<p>Deviates: No indented code blocks.</p>
+<p><a/>
+<strong>hi</strong></p>
+<ul>
+<li>
+<p>one</p>
+</li>
+</ul>

--- a/mark/tests/fixtures/cm/indented-code-blocks-80.md
+++ b/mark/tests/fixtures/cm/indented-code-blocks-80.md
@@ -1,3 +1,5 @@
+Deviates: No indented code blocks.
+
     <a/>
     *hi*
 

--- a/mark/tests/fixtures/cm/indented-code-blocks-81.html
+++ b/mark/tests/fixtures/cm/indented-code-blocks-81.html
@@ -1,8 +1,4 @@
-<pre><code>chunk1
-
-chunk2
-
-
-
-chunk3
-</code></pre>
+<p>Deviates: No indented code blocks.</p>
+<p>chunk1</p>
+<p>chunk2</p>
+<p>chunk3</p>

--- a/mark/tests/fixtures/cm/indented-code-blocks-81.md
+++ b/mark/tests/fixtures/cm/indented-code-blocks-81.md
@@ -1,3 +1,5 @@
+Deviates: No indented code blocks.
+
     chunk1
 
     chunk2

--- a/mark/tests/fixtures/cm/indented-code-blocks-82.html
+++ b/mark/tests/fixtures/cm/indented-code-blocks-82.html
@@ -1,4 +1,3 @@
-<pre><code>chunk1
-  
-  chunk2
-</code></pre>
+<p>Deviates: No indented code blocks.</p>
+<p>chunk1</p>
+<p>chunk2</p>

--- a/mark/tests/fixtures/cm/indented-code-blocks-82.md
+++ b/mark/tests/fixtures/cm/indented-code-blocks-82.md
@@ -1,3 +1,5 @@
+Deviates: No indented code blocks.
+
     chunk1
       
       chunk2

--- a/mark/tests/fixtures/cm/indented-code-blocks-84.html
+++ b/mark/tests/fixtures/cm/indented-code-blocks-84.html
@@ -1,3 +1,3 @@
-<pre><code>foo
-</code></pre>
-<p>bar</p>
+<p>Deviates: No indented code blocks.</p>
+<p>foo
+bar</p>

--- a/mark/tests/fixtures/cm/indented-code-blocks-84.md
+++ b/mark/tests/fixtures/cm/indented-code-blocks-84.md
@@ -1,2 +1,4 @@
+Deviates: No indented code blocks.
+
     foo
 bar

--- a/mark/tests/fixtures/cm/indented-code-blocks-85.html
+++ b/mark/tests/fixtures/cm/indented-code-blocks-85.html
@@ -1,7 +1,5 @@
+<p>Deviates: No indented code blocks.</p>
 <h1>Heading</h1>
-<pre><code>foo
-</code></pre>
-<h2>Heading</h2>
-<pre><code>foo
-</code></pre>
-<hr />
+<h2>foo
+Heading</h2>
+<h2>foo</h2>

--- a/mark/tests/fixtures/cm/indented-code-blocks-85.md
+++ b/mark/tests/fixtures/cm/indented-code-blocks-85.md
@@ -1,3 +1,5 @@
+Deviates: No indented code blocks.
+
 # Heading
     foo
 Heading

--- a/mark/tests/fixtures/cm/indented-code-blocks-86.html
+++ b/mark/tests/fixtures/cm/indented-code-blocks-86.html
@@ -1,3 +1,3 @@
-<pre><code>    foo
-bar
-</code></pre>
+<p>Deviates: No indented code blocks.</p>
+<p>foo
+bar</p>

--- a/mark/tests/fixtures/cm/indented-code-blocks-86.md
+++ b/mark/tests/fixtures/cm/indented-code-blocks-86.md
@@ -1,2 +1,4 @@
+Deviates: No indented code blocks.
+
         foo
     bar

--- a/mark/tests/fixtures/cm/indented-code-blocks-87.html
+++ b/mark/tests/fixtures/cm/indented-code-blocks-87.html
@@ -1,2 +1,2 @@
-<pre><code>foo
-</code></pre>
+<p>Deviates: No indented code blocks.</p>
+<p>foo</p>

--- a/mark/tests/fixtures/cm/indented-code-blocks-87.md
+++ b/mark/tests/fixtures/cm/indented-code-blocks-87.md
@@ -1,4 +1,4 @@
-
+Deviates: No indented code blocks.
     
     foo
     

--- a/mark/tests/fixtures/cm/indented-code-blocks-88.html
+++ b/mark/tests/fixtures/cm/indented-code-blocks-88.html
@@ -1,2 +1,2 @@
-<pre><code>foo  
-</code></pre>
+<p>Deviates: No indented code blocks.</p>
+<p>foo</p>

--- a/mark/tests/fixtures/cm/indented-code-blocks-88.md
+++ b/mark/tests/fixtures/cm/indented-code-blocks-88.md
@@ -1,1 +1,3 @@
+Deviates: No indented code blocks.
+
     foo  

--- a/mark/tests/fixtures/cm/mod.rs
+++ b/mark/tests/fixtures/cm/mod.rs
@@ -385,7 +385,6 @@ fn setext_headings_76() {
 }
 
 #[test]
-#[ignore]
 fn indented_code_blocks_77() {
     compare("cm/indented-code-blocks-77")
 }
@@ -396,25 +395,21 @@ fn indented_code_blocks_78() {
 }
 
 #[test]
-#[ignore]
 fn indented_code_blocks_79() {
     compare("cm/indented-code-blocks-79")
 }
 
 #[test]
-#[ignore]
 fn indented_code_blocks_80() {
     compare("cm/indented-code-blocks-80")
 }
 
 #[test]
-#[ignore]
 fn indented_code_blocks_81() {
     compare("cm/indented-code-blocks-81")
 }
 
 #[test]
-#[ignore]
 fn indented_code_blocks_82() {
     compare("cm/indented-code-blocks-82")
 }
@@ -425,31 +420,26 @@ fn indented_code_blocks_83() {
 }
 
 #[test]
-#[ignore]
 fn indented_code_blocks_84() {
     compare("cm/indented-code-blocks-84")
 }
 
 #[test]
-#[ignore]
 fn indented_code_blocks_85() {
     compare("cm/indented-code-blocks-85")
 }
 
 #[test]
-#[ignore]
 fn indented_code_blocks_86() {
     compare("cm/indented-code-blocks-86")
 }
 
 #[test]
-#[ignore]
 fn indented_code_blocks_87() {
     compare("cm/indented-code-blocks-87")
 }
 
 #[test]
-#[ignore]
 fn indented_code_blocks_88() {
     compare("cm/indented-code-blocks-88")
 }


### PR DESCRIPTION
These tests are pretty much all marked as deviating as we don't support
indented code blocks. The result HTML has been updated to what is
produced in our case.